### PR TITLE
Veprbl and mvorl patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmake-build-debug/
+cmake-build-release/
 build/
 .idea/

--- a/src/AliM1543C.cpp
+++ b/src/AliM1543C.cpp
@@ -1222,7 +1222,7 @@ void CAliM1543C::pic_deassert(int index, int intno) {
     return;
 
   //  printf("De-asserting %d,%d\n",index,intno);
-  state.pic_asserted[index] &= !(1 << intno);
+  state.pic_asserted[index] &= ~(1 << intno);
   if (index == 1 && state.pic_asserted[1] == 0)
     pic_deassert(0, 2); // cascade
   if (index == 0 && state.pic_asserted[0] == 0)

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -613,6 +613,66 @@ void CAlphaCPU::execute() {
 #endif
   state.current_pc = state.pc;
 
+    if (state.current_pc == U64(0x8bb90))
+    {
+        if (state.r[5] != U64(0xaaaaaaaaaaaaaaaa))
+        {
+            printf("wrong memory check skip!\n");
+        }
+        else
+        {
+            state.r[0] = state.r[4];
+        }
+    }
+
+    if (state.current_pc == U64(0x8bbe0))
+    {
+        if (state.r[5] != U64(0xaaaaaaaaaaaaaaaa))
+        {
+            printf("wrong memory check skip!\n");
+        }
+        else
+        {
+            state.r[16] = 0;
+        }
+    }
+
+    if (state.current_pc == U64(0x8bc28))
+    {
+        if (state.r[5] != U64(0xaaaaaaaaaaaaaaaa))
+        {
+            printf("wrong memory check skip!\n");
+        }
+        else
+        {
+            state.r[8] = state.r[4];
+        }
+    }
+
+    if (state.current_pc == U64(0x8bc70))
+    {
+        if (state.r[7] != U64(0x5555555555555555))
+        {
+            printf("wrong memory check skip1!\n");
+        }
+        else
+        {
+            state.r[0] = 0;
+        }
+    }
+
+    if (state.current_pc == U64(0x8bcb0))
+    {
+        if (state.r[7] != U64(0x5555555555555555))
+        {
+            printf("wrong memory check skip2!\n");
+        }
+        else
+        {
+            state.r[3] = state.r[4];
+        }
+    }
+
   // Service interrupts
   if (DO_ACTION) {
 

--- a/src/AlphaCPU.h
+++ b/src/AlphaCPU.h
@@ -564,6 +564,8 @@ private:
   u64 last_read_loc;
   u64 last_write_loc;
 #endif
+
+    void skip_memtest();
 };
 
 /** Translate raw register (0..31) number to a number that takes PALshadow

--- a/src/AlphaCPU_ieeefloat.cpp
+++ b/src/AlphaCPU_ieeefloat.cpp
@@ -877,7 +877,7 @@ u64 CAlphaCPU::ieee_rpack(UFP *r, u32 ins, u32 dp) {
 void CAlphaCPU::ieee_trap(u64 trap, u32 instenb, u64 fpcrdsb, u32 ins) {
   u64 real_trap = U64(0x0);
 
-  if (!(state.fpcr & (trap << 51))) // trap bit not set in FPCR
+  if (~(state.fpcr & (trap << 51))) // trap bit not set in FPCR
     real_trap |= trap << 41;        // SET trap bit in EXC_SUM
   if ((instenb != 0)                /* not enabled in inst? ignore */
       && !((ins & I_FTRP_S) &&

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -370,7 +370,7 @@ void CDEC21143::init() {
   if (!cfg) {
     printf("\n%s: Choose a network adapter to connect to:\n", devid_string);
     if (pcap_findalldevs(&alldevs, errbuf) == -1) {
-      throw std::runtime_error("Error in pcap_findalldevs_ex: " + std::string(errbuf));
+      FAILURE_1(Runtime, "Error in pcap_findalldevs_ex: %s", errbuf);
     }
 
     /* Print the list */
@@ -383,7 +383,7 @@ void CDEC21143::init() {
     }
 
     if (i == 0)
-        throw std::runtime_error("No network interfaces found");
+      FAILURE(Runtime, "No network interfaces found");
 
     if (i == 1)
       inum = 1;
@@ -426,13 +426,14 @@ void CDEC21143::init() {
                       errbuf)) == NULL) // connect to pcap...
 #else
   if ((fp = pcap_open_live(cfg, 65536 /*snaplen: capture entire packets */,
-                           1 /*promiscuous */, 10 /*read timeout: 10ms. */,
-                           errbuf)) == nullptr) // connect to pcap...
+                           1 /*promiscuous */, 1 /*read timeout: 1ms. */,
+                           errbuf)) == NULL) // connect to pcap...
 #endif
-    throw std::runtime_error("Error opening adapter " + std::string(cfg) + " : " + errbuf);
+    FAILURE_2(Runtime, "Error opening adapter %s:\n %s", cfg, errbuf);
 
   if (pcap_setnonblock(fp, 1, errbuf) == PCAP_ERROR)
-    throw std::runtime_error("Error setting adapter " + std::string(cfg) + " non-blocking: " + errbuf);
+    FAILURE_2(Runtime, "Error setting adapter %s non-blocking:\n %s", cfg,
+              errbuf);
 
   // set default mac = Digital ethernet prefix: 08-00-2B + hexified "ES40" + nic
   // number

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -426,7 +426,7 @@ void CDEC21143::init() {
                       errbuf)) == NULL) // connect to pcap...
 #else
   if ((fp = pcap_open_live(cfg, 65536 /*snaplen: capture entire packets */,
-                           1 /*promiscuous */, 1 /*read timeout: 1ms. */,
+                           1 /*promiscuous */, 10 /*read timeout: 10ms. */,
                            errbuf)) == nullptr) // connect to pcap...
 #endif
     throw std::runtime_error("Error opening adapter " + std::string(cfg) + " : " + errbuf);

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -370,7 +370,7 @@ void CDEC21143::init() {
   if (!cfg) {
     printf("\n%s: Choose a network adapter to connect to:\n", devid_string);
     if (pcap_findalldevs(&alldevs, errbuf) == -1) {
-      FAILURE_1(Runtime, "Error in pcap_findalldevs_ex: %s", errbuf);
+      throw std::runtime_error("Error in pcap_findalldevs_ex: " + std::string(errbuf));
     }
 
     /* Print the list */
@@ -383,7 +383,7 @@ void CDEC21143::init() {
     }
 
     if (i == 0)
-      FAILURE(Runtime, "No network interfaces found");
+        throw std::runtime_error("No network interfaces found");
 
     if (i == 1)
       inum = 1;
@@ -426,14 +426,13 @@ void CDEC21143::init() {
                       errbuf)) == NULL) // connect to pcap...
 #else
   if ((fp = pcap_open_live(cfg, 65536 /*snaplen: capture entire packets */,
-                           1 /*promiscuous */, 1 /*read timeout: 1ms. */,
-                           errbuf)) == NULL) // connect to pcap...
+                           1 /*promiscuous */, 10 /*read timeout: 10ms. */,
+                           errbuf)) == nullptr) // connect to pcap...
 #endif
-    FAILURE_2(Runtime, "Error opening adapter %s:\n %s", cfg, errbuf);
+    throw std::runtime_error("Error opening adapter " + std::string(cfg) + " : " + errbuf);
 
   if (pcap_setnonblock(fp, 1, errbuf) == PCAP_ERROR)
-    FAILURE_2(Runtime, "Error setting adapter %s non-blocking:\n %s", cfg,
-              errbuf);
+    throw std::runtime_error("Error setting adapter " + std::string(cfg) + " non-blocking: " + errbuf);
 
   // set default mac = Digital ethernet prefix: 08-00-2B + hexified "ES40" + nic
   // number

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -426,7 +426,7 @@ void CDEC21143::init() {
                       errbuf)) == NULL) // connect to pcap...
 #else
   if ((fp = pcap_open_live(cfg, 65536 /*snaplen: capture entire packets */,
-                           1 /*promiscuous */, 10 /*read timeout: 10ms. */,
+                           1 /*promiscuous */, 1 /*read timeout: 1ms. */,
                            errbuf)) == nullptr) // connect to pcap...
 #endif
     throw std::runtime_error("Error opening adapter " + std::string(cfg) + " : " + errbuf);


### PR DESCRIPTION
Added the following:

From @veprbl: 

- https://github.com/veprbl/es40/commit/3f2e410c50670a8edcc5edc6b7da8842ec0f80d5 (skip srm memtest 1)
- https://github.com/veprbl/es40/commit/8bf4c91d40ff07b73939340b8d4a320c9fce6084#diff-c2e85483170eecdd55efe0ce7e3d09aab6d8112dc6630531f6ee14762687333f (skip srm memtest 2)
- https://github.com/veprbl/es40/commit/ac7e9a8b1e6df65121aa1944021af8d81aaad83f (netbsd boot)

From @mvorl:

- https://github.com/mvorl/es40/commit/980050d2d5db9210b00f4a4084e3cc219f839fe4 ( Replaced ! by ~ )
- https://github.com/mvorl/es40/commit/9ec73eb50e3261075cba33bbb583476ef1141f89 (  Replaced ! by ~  )

One change of my own, in the network code, throw a std::runtime instead of the macro. This branch started as my network troubleshooting branch, then I found the skip memtest patch, then I thought, lets take all the interesting patches. It still had the network debug in there, which I removed, but left the throw.