### PR TITLE
Add git version info to usage output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,21 +136,7 @@ if (GIT_FOUND)
         OUTPUT_VARIABLE GIT_SHA
         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    execute_process(COMMAND
-            "${GIT_EXECUTABLE}" log -1 --format=%ad --date=local
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-            OUTPUT_VARIABLE GIT_DATE
-            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    execute_process(COMMAND
-            "${GIT_EXECUTABLE}" log -1 --format=%s
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-            OUTPUT_VARIABLE GIT_COMMIT_SUBJECT
-            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    set(GITINFO "SHA1: ${GIT_SHA}; Date: ${GIT_DATE}; Commit subject: ${GIT_COMMIT_SUBJECT}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGITINFO='\"${GITINFO}\"'")
-    message(STATUS "Git info: ${GITINFO}")
+    set(PACKAGE_GITSHA "\"${GIT_SHA}\"")
 endif()
 
 set(PACKAGE ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ list(REMOVE_ITEM srcs ${include_sources})
 
 add_executable(axpbox ${srcs} src/Main.cpp)
 target_include_directories(axpbox PRIVATE src src/base src/gui ${CMAKE_BINARY_DIR}/src)
+find_package(Threads REQUIRED)
 target_link_libraries(axpbox pthread)
 
 # Configuration options
@@ -125,6 +126,31 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -DNDEBUG")
+endif()
+
+find_package(Git)
+if (GIT_FOUND)
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}" describe --match=NeVeRmAtCh --always --abbrev=40 --dirty
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE GIT_SHA
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    execute_process(COMMAND
+            "${GIT_EXECUTABLE}" log -1 --format=%ad --date=local
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            OUTPUT_VARIABLE GIT_DATE
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    execute_process(COMMAND
+            "${GIT_EXECUTABLE}" log -1 --format=%s
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            OUTPUT_VARIABLE GIT_COMMIT_SUBJECT
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(GITINFO "SHA1: ${GIT_SHA}; Date: ${GIT_DATE}; Commit subject: ${GIT_COMMIT_SUBJECT}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGITINFO='\"${GITINFO}\"'")
+    message(STATUS "Git info: ${GITINFO}")
 endif()
 
 set(PACKAGE ${PROJECT_NAME})

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -5,15 +5,16 @@
 #include <cstring>
 #include <iostream>
 
-using namespace std;
-
 int main_sim(int argc, char *argv[]);
 int main_cfg(int argc, char *argv[]);
 
 int main(int argc, char **argv) {
   if (argc <= 1 || (strcmp(argv[1], "run") && strcmp(argv[1], "configure"))) {
-    cerr << "AXPBox Alpha Emulator (version 0.1)" << endl
-         << "Usage: " << argv[0] << " run|configure <options>" << endl;
+    std::cerr << "AXPBox Alpha Emulator" << std::endl;
+#ifdef GITINFO
+    std::cerr << "Git version info: " << std::string(GITINFO) << std::endl;
+#endif
+    std::cerr << "Usage: " << argv[0] << " run|configure <options>" << std::endl;
     return 1;
   }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,7 +1,7 @@
 //
 // Created by tglozar on 21.09.20.
 //
-
+#include "config.h"
 #include <cstring>
 #include <iostream>
 
@@ -10,12 +10,11 @@ int main_cfg(int argc, char *argv[]);
 
 int main(int argc, char **argv) {
   if (argc <= 1 || (strcmp(argv[1], "run") && strcmp(argv[1], "configure"))) {
-    std::cerr << "AXPBox Alpha Emulator" << std::endl;
-#ifdef GITINFO
-    std::cerr << "Git version info: " << std::string(GITINFO) << std::endl;
-#else
-    std::cerr << "No git version information available during build." << std::endl;
+    std::cerr << "AXPBox Alpha Emulator";
+#ifdef PACKAGE_GITSHA
+    std::cerr << " (commit " << std::string(PACKAGE_GITSHA) << ")";
 #endif
+    std::cerr << std::endl;
     std::cerr << "Usage: " << argv[0] << " run|configure <options>" << std::endl;
     return 1;
   }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -13,6 +13,8 @@ int main(int argc, char **argv) {
     std::cerr << "AXPBox Alpha Emulator" << std::endl;
 #ifdef GITINFO
     std::cerr << "Git version info: " << std::string(GITINFO) << std::endl;
+#else
+    std::cerr << "No git version information available during build." << std::endl;
 #endif
     std::cerr << "Usage: " << argv[0] << " run|configure <options>" << std::endl;
     return 1;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -228,6 +228,10 @@
 /* Define to the version of this package. */
 #cmakedefine PACKAGE_VERSION @PACKAGE_VERSION@
 
+/* Define to the git revision of this package. */
+#cmakedefine PACKAGE_GITSHA @PACKAGE_GITSHA@
+
+
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */
 #cmakedefine PTHREAD_CREATE_JOINABLE @PTHREAD_CREATE_JOINABLE@


### PR DESCRIPTION
I'm not sure how you feel about including a version number, here's a quick demo with cmake and git, included in the 
main output (if no args are given). It might be suitable until actual versions/releases are managed.

Here's example output:

```
[21:35:59] [remy@gateway] [ ~/tmp/axpbox/build (git_version_info_in_usage_output) ]
$ ./axpbox 
AXPBox Alpha Emulator
Git version info: SHA1: 6ef090e610f2a154e11b645c8f72a3dbeb3fe3bd; Date: Sat Nov 7 21:34:46 2020; Commit subject: Add git version info to usage output. Includes commit hash, commit date and commit subject.
Usage: ./axpbox run|configure <options>
```

No substitute for an actual version number, but does give users information about which build they're running. Now that so many improvements are happening, it will probably help with bug reports in the future, if it's known which version is being used.
