### PR TITLE
GitHub actions build

### DIFF
--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -34,10 +34,10 @@ jobs:
       env:
         MAKEFLAGS: "-j2"
 
-    - name: Run test script ROM
-      working-directory: ${{runner.workspace}}/axpbox/test/rom
+    - name: Run test scripts
+      working-directory: ${{runner.workspace}}/axpbox/test
       shell: bash
-      run: ${{runner.workspace}}/axpbox/test/rom/test.sh
+      run: ${{runner.workspace}}/axpbox/test/run
 
     - name: Upload AXPbox artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -66,7 +66,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Werror"
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -102,7 +102,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Werror"
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -121,7 +121,7 @@ jobs:
 
   build-windows-msvc:
     runs-on: windows-2019
-
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v2
 
@@ -135,7 +135,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -154,7 +154,8 @@ jobs:
 
   build-osx-appleclang:
     runs-on: "macos-10.15"
-
+    continue-on-error: true
+    
     steps:
     - uses: actions/checkout@v2
 
@@ -168,7 +169,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -184,3 +185,4 @@ jobs:
         path: ${{runner.workspace}}/build/axpbox 
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 
+

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -4,8 +4,9 @@ on: [push, pull_request]
 
 jobs:
 
-  test-linux:
+  linux-clang:
     runs-on: "ubuntu-20.04"
+
     steps:
     - uses: actions/checkout@v2
 
@@ -14,10 +15,48 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
 
     - name: Install build dependencies
-      run: sudo apt -y update && sudo apt -y install ncat libpcap-dev libsdl-dev
+      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev netcat-openbsd
 
-    - name: Install test dependencies
-      run: sudo apt -y update && sudo apt -y install ncat
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Run test scripts
+      working-directory: ${{runner.workspace}}/axpbox
+      shell: bash
+      run: ${{runner.workspace}}/axpbox/test/run
+
+    - name: Upload AXPbox binary
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-linux-clang-${{ env.BUILD_DATE }}
+        path: ${{runner.workspace}}/build/axpbox 
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }}
+
+  linux-gcc:
+    runs-on: "ubuntu-20.04"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Install build dependencies
+      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev netcat-openbsd
 
     - name: Create build environment
       run: cmake -E make_directory ${{runner.workspace}}/build
@@ -39,78 +78,6 @@ jobs:
       shell: bash
       run: ${{runner.workspace}}/axpbox/test/run
 
-    - name: Upload AXPbox artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: AXPbox-linux-test-${{ env.BUILD_DATE }}
-        path: ${{runner.workspace}}/build/axpbox 
-      env:
-        BUILD_DATE: ${{ steps.date.outputs.date }}
-
-  build-linux-clang:
-    runs-on: "ubuntu-20.04"
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
-
-    - name: Install build dependencies
-      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev
-
-    - name: Create build environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
-
-    - name: Build
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build . --config Release
-      env:
-        MAKEFLAGS: "-j2"
-
-    - name: Upload AXPbox binary
-      uses: actions/upload-artifact@v1
-      with:
-        name: AXPbox-linux-clang-${{ env.BUILD_DATE }}
-        path: ${{runner.workspace}}/build/axpbox 
-      env:
-        BUILD_DATE: ${{ steps.date.outputs.date }}
-
-  build-linux-gcc:
-    runs-on: "ubuntu-20.04"
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
-
-    - name: Install build dependencies
-      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev
-
-    - name: Create build environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
-
-    - name: Build
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build . --config Release
-      env:
-        MAKEFLAGS: "-j2"
-
     - name: Upload AXPbox binary
       uses: actions/upload-artifact@v1
       with:
@@ -119,7 +86,7 @@ jobs:
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 
 
-  build-windows-msvc:
+  windows-msvc:
     runs-on: windows-2019
     continue-on-error: true
     steps:
@@ -152,7 +119,7 @@ jobs:
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 
 
-  build-osx-appleclang:
+  osx-appleclang:
     runs-on: "macos-10.15"
     continue-on-error: true
     
@@ -183,6 +150,11 @@ jobs:
       run: cmake --build . --config Release
       env:
         MAKEFLAGS: "-j2"
+
+    - name: Run test scripts
+      working-directory: ${{runner.workspace}}/axpbox
+      shell: bash
+      run: ${{runner.workspace}}/axpbox/test/run
 
     - name: Upload AXPbox Binary
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -166,6 +166,9 @@ jobs:
     - name: Create build environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 
+    - name: Install dependencies
+      run: brew install sdl2 libpcap libx11
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -167,12 +167,15 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Install dependencies
-      run: brew install sdl2 libpcap libx11
+      run: brew install coreutils libpcap netcat # sdl2 libx11
+
+    - name: gnu tr
+      run: sudo mv /usr/local/opt/coreutils/libexec/gnubin/tr /usr/bin/tr
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wc++11-extensions -Wc++11-long-long -Wc++11-extra-semi -std=c++11 -stdlib=libc++ -I/usr/local/opt/libpcap/include"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -35,7 +35,7 @@ jobs:
         MAKEFLAGS: "-j2"
 
     - name: Run test scripts
-      working-directory: ${{runner.workspace}}/axpbox/test
+      working-directory: ${{runner.workspace}}/axpbox
       shell: bash
       run: ${{runner.workspace}}/axpbox/test/run
 

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -1,0 +1,186 @@
+name: Build, run test and upload binaries 
+
+on: [push, pull_request]
+
+jobs:
+
+  test-linux:
+    runs-on: "ubuntu-20.04"
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Install build dependencies
+      run: sudo apt -y update && sudo apt -y install ncat libpcap-dev libsdl-dev
+
+    - name: Install test dependencies
+      run: sudo apt -y update && sudo apt -y install ncat
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Run test script ROM
+      working-directory: ${{runner.workspace}}/axpbox/test/rom
+      shell: bash
+      run: ${{runner.workspace}}/axpbox/test/rom/test.sh
+
+    - name: Upload AXPbox artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-linux-test-${{ env.BUILD_DATE }}
+        path: ${{runner.workspace}}/build/axpbox 
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }}
+
+  build-linux-clang:
+    runs-on: "ubuntu-20.04"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Install build dependencies
+      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Werror"
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Upload AXPbox binary
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-linux-clang-${{ env.BUILD_DATE }}
+        path: ${{runner.workspace}}/build/axpbox 
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }}
+
+  build-linux-gcc:
+    runs-on: "ubuntu-20.04"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Install build dependencies
+      run: sudo apt -y update && sudo apt -y install libpcap-dev libsdl-dev
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Werror"
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Upload AXPbox binary
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-linux-gcc-${{ env.BUILD_DATE }}
+        path: ${{runner.workspace}}/build/axpbox
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }} 
+
+  build-windows-msvc:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Upload AXPbox Binary
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-windows-msvc-${{ env.BUILD_DATE }}.exe
+        path: ${{runner.workspace}}/build/axpbox 
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }} 
+
+  build-osx-appleclang:
+    runs-on: "macos-10.15"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config Release
+      env:
+        MAKEFLAGS: "-j2"
+
+    - name: Upload AXPbox Binary
+      uses: actions/upload-artifact@v1
+      with:
+        name: AXPbox-osx-appleclang-${{ env.BUILD_DATE }}
+        path: ${{runner.workspace}}/build/axpbox 
+      env:
+        BUILD_DATE: ${{ steps.date.outputs.date }} 

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -151,11 +151,6 @@ jobs:
       env:
         MAKEFLAGS: "-j2"
 
-    - name: Run test scripts
-      working-directory: ${{runner.workspace}}/axpbox
-      shell: bash
-      run: ${{runner.workspace}}/axpbox/test/run
-
     - name: Upload AXPbox Binary
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -134,15 +134,12 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Install dependencies
-      run: brew install coreutils libpcap netcat # sdl2 libx11
-
-    - name: gnu tr
-      run: sudo mv /usr/local/opt/coreutils/libexec/gnubin/tr /usr/bin/tr
+      run: brew install libpcap netcat gnu-sed # sdl2 libx11 / sdl doesnt work see #44
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wc++11-extensions -Wc++11-long-long -Wc++11-extra-semi -std=c++11 -stdlib=libc++ -I/usr/local/opt/libpcap/include"
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -std=c++11 -stdlib=libc++ -I/usr/local/opt/libpcap/include"
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -151,10 +148,15 @@ jobs:
       env:
         MAKEFLAGS: "-j2"
 
+    - name: Run test scripts
+      working-directory: ${{runner.workspace}}/axpbox
+      shell: bash
+      run: ${{runner.workspace}}/axpbox/test/run
+
     - name: Upload AXPbox Binary
       uses: actions/upload-artifact@v1
       with:
-        name: AXPbox-osx-appleclang-${{ env.BUILD_DATE }}
+        name: AXPbox-osx-10.15-appleclang-${{ env.BUILD_DATE }}
         path: ${{runner.workspace}}/build/axpbox 
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -86,39 +86,6 @@ jobs:
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 
 
-  windows-msvc:
-    runs-on: windows-2019
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H%M')"
-
-    - name: Create build environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall"
-
-    - name: Build
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build . --config Release
-      env:
-        MAKEFLAGS: "-j2"
-
-    - name: Upload AXPbox Binary
-      uses: actions/upload-artifact@v1
-      with:
-        name: AXPbox-windows-msvc-${{ env.BUILD_DATE }}.exe
-        path: ${{runner.workspace}}/build/axpbox 
-      env:
-        BUILD_DATE: ${{ steps.date.outputs.date }} 
-
   osx-appleclang:
     runs-on: "macos-10.15"
     continue-on-error: true

--- a/test/disk/unwritable/test.sh
+++ b/test/disk/unwritable/test.sh
@@ -9,7 +9,13 @@ if [[ ! -f "cl67srmrom.exe" ]]; then
 fi
 
 # Start AXPbox
-../../../build/axpbox run | tee axp.log
+if [[ -f ../../../build/axpbox ]]; then
+  ../../../build/axpbox run | tee axp.log
+elif [[ -f ../../../../build/axpbox ]]; then
+  ../../../../build/axpbox run | tee axp.log;
+else
+   ../../build/axpbox run | tee axp.log
+fi
 
 chmod 700 disk-unwritable.img
 rm disk-unwritable.img

--- a/test/disk/unwritable/test.sh
+++ b/test/disk/unwritable/test.sh
@@ -20,8 +20,13 @@ fi
 chmod 700 disk-unwritable.img
 rm disk-unwritable.img
 
-sed -i -e 's$/[^ ]*/DiskFile.cpp$DiskFile.cpp$g' \
-    -e 's/line [0-9]*/line L/g' -e '/$Id/d' axp.log
+# OS X github runner has weiro sed version, use gnu one there.
+SED=/usr/bin/sed
+if [[ -f "/usr/local/opt/gnu-sed/libexec/gnubin/sed" ]]; then
+  SED=/usr/local/opt/gnu-sed/libexec/gnubin/sed
+fi
+
+${SED} -i -e 's$/[^ ]*/DiskFile.cpp$DiskFile.cpp$g' -e 's/line [0-9]*/line L/g' -e '/$Id/d' axp.log
 
 echo -n -e '\033[1;31m'
 diff -c axp_correct.log axp.log && echo -e '\033[1;32mdiff clean\033[0m'

--- a/test/rom/test.sh
+++ b/test/rom/test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+export LC_CTYPE=C
+export LANG=C
+export LC_ALL=C
 
 # Download the firmware
 wget 'http://raymii.org/s/inc/downloads/es40-srmon/cl67srmrom.exe'

--- a/test/rom/test.sh
+++ b/test/rom/test.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
 # Download the firmware
-wget 'http://80.211.96.38/s/inc/downloads/es40-srmon/cl67srmrom.exe'
+wget 'http://raymii.org/s/inc/downloads/es40-srmon/cl67srmrom.exe'
 
 # Start AXPbox
-../../build/axpbox run &
-AXPBOX_PID=$!
+if [[ -f ../../../build/axpbox ]]; then
+  ../../../build/axpbox run &
+  AXPBOX_PID=$!
+else # Travis
+  ../../build/axpbox run &
+  AXPBOX_PID=$!
+fi
 
 # Wait for AXPbox to start
 sleep 3

--- a/test/rom/test.sh
+++ b/test/rom/test.sh
@@ -32,7 +32,7 @@ do
     exit 1
   fi
 
-  if [ "$(tail -n 1 axp.log | tr -d '\0')" == "P00>>>"  ]
+  if [ "$(tail -n 1 axp.log | LC_ALL=C tr -d '\0')" == "P00>>>"  ]
   then
     echo
     break

--- a/test/rom/test.sh
+++ b/test/rom/test.sh
@@ -16,14 +16,14 @@ else # Travis
 fi
 
 # Wait for AXPbox to start
-sleep 3
+sleep 5
 
 # Connect to terminal
 nc -t 127.0.0.1 21000 | tee axp.log &
 NETCAT_PID=$!
 
 # Wait for the last line of log to become P00>>>
-timeout=300
+timeout=100
 while true
 do
   if [ $timeout -eq 0 ]
@@ -32,7 +32,8 @@ do
     exit 1
   fi
 
-  if [ "$(tail -n 1 axp.log | LC_ALL=C tr -d '\0')" == "P00>>>"  ]
+  # print last line and remove null byte from it
+  if [ "$(LC_ALL=C sed -n '$p' axp.log | LC_ALL=C sed 's/\x00//g')" == "P00>>>"  ]
   then
     echo
     break


### PR DESCRIPTION
Discussed a bit already in #22 , I've created a github actions workflow file, which builds axpbox on all platforms supported by the github runners (linux clang/gcc, os x and msvc). If the build succeeds, the resulting binary is uploaded. This binary can be downloaded by users or can later be used to make a "github release". 

Currently the linux gcc and windows builds fail, but fixing that should be a different branch IMHO. (Which is why the run currently fails)