### PR TITLE
Gcc compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,6 @@ else()
     message(WARNING "x11 not found. Building without x11 graphics support")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
-
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Og -ggdb")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og -ggdb")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ else()
     message(WARNING "x11 not found. Building without x11 graphics support")
 endif()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Og -ggdb")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og -ggdb")

--- a/src/AliM1543C.cpp
+++ b/src/AliM1543C.cpp
@@ -1283,7 +1283,7 @@ int CAliM1543C::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -1294,7 +1294,7 @@ int CAliM1543C::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/AliM1543C_ide.cpp
+++ b/src/AliM1543C_ide.cpp
@@ -544,7 +544,7 @@ int CAliM1543C_ide::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -555,7 +555,7 @@ int CAliM1543C_ide::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/AliM1543C_usb.cpp
+++ b/src/AliM1543C_usb.cpp
@@ -357,7 +357,7 @@ int CAliM1543C_usb::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -368,7 +368,7 @@ int CAliM1543C_usb::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -1572,7 +1572,7 @@ int CAlphaCPU::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -1583,7 +1583,7 @@ int CAlphaCPU::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Cirrus.cpp
+++ b/src/Cirrus.cpp
@@ -621,7 +621,7 @@ int CCirrus::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -632,7 +632,7 @@ int CCirrus::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -389,7 +389,7 @@ void CDEC21143::init() {
       inum = 0;
       while (inum < 1 || inum > i) {
         printf("%%NIC-Q-NICNO: Enter the interface number (1-%d):", i);
-        scanf("%d", &inum);
+        (void)!scanf("%d", &inum);
       }
     }
 
@@ -1707,7 +1707,7 @@ int CDEC21143::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -1718,7 +1718,7 @@ int CDEC21143::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -370,7 +370,7 @@ int CDMA::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("dma: unexpected end of file!\n");
     return -1;
@@ -381,7 +381,7 @@ int CDMA::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("dma: unexpected end of file!\n");
     return -1;

--- a/src/DPR.cpp
+++ b/src/DPR.cpp
@@ -697,7 +697,7 @@ int CDPR::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", "dpr");
     return -1;
@@ -708,7 +708,7 @@ int CDPR::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", "dpr");
     return -1;

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -247,7 +247,7 @@ int CDisk::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -258,7 +258,7 @@ int CDisk::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Flash.cpp
+++ b/src/Flash.cpp
@@ -377,7 +377,7 @@ int CFlash::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("flash: unexpected end of file!\n");
     return -1;
@@ -388,7 +388,7 @@ int CFlash::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("flash: unexpected end of file!\n");
     return -1;

--- a/src/FloppyController.cpp
+++ b/src/FloppyController.cpp
@@ -442,7 +442,7 @@ int CFloppyController::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("fdc: unexpected end of file!\n");
     return -1;
@@ -453,7 +453,7 @@ int CFloppyController::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("fdc: unexpected end of file!\n");
     return -1;

--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -1791,7 +1791,7 @@ int CKeyboard::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("kbc: unexpected end of file!\n");
     return -1;
@@ -1802,7 +1802,7 @@ int CKeyboard::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("kbc: unexpected end of file!\n");
     return -1;

--- a/src/PCIDevice.cpp
+++ b/src/PCIDevice.cpp
@@ -472,7 +472,7 @@ int CPCIDevice::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -483,7 +483,7 @@ int CPCIDevice::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&pci_state, sizeof(pci_state), 1, f);
+  r = fread(&pci_state, sizeof(pci_state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Port80.cpp
+++ b/src/Port80.cpp
@@ -133,7 +133,7 @@ int CPort80::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -144,7 +144,7 @@ int CPort80::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/S3Trio64.cpp
+++ b/src/S3Trio64.cpp
@@ -609,7 +609,7 @@ int CS3Trio64::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -620,7 +620,7 @@ int CS3Trio64::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/SCSIBus.cpp
+++ b/src/SCSIBus.cpp
@@ -201,7 +201,7 @@ int CSCSIBus::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -212,7 +212,7 @@ int CSCSIBus::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -688,7 +688,7 @@ int CSerial::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -699,7 +699,7 @@ int CSerial::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Sym53C810.cpp
+++ b/src/Sym53C810.cpp
@@ -756,7 +756,7 @@ int CSym53C810::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -767,7 +767,7 @@ int CSym53C810::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/Sym53C895.cpp
+++ b/src/Sym53C895.cpp
@@ -857,7 +857,7 @@ int CSym53C895::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&ss, sizeof(long), 1, f);
+  r = fread(&ss, sizeof(long), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;
@@ -868,7 +868,7 @@ int CSym53C895::RestoreState(FILE *f) {
     return -1;
   }
 
-  fread(&state, sizeof(state), 1, f);
+  r = fread(&state, sizeof(state), 1, f);
   if (r != 1) {
     printf("%s: unexpected end of file!\n", devid_string);
     return -1;

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -1871,14 +1871,14 @@ int CSystem::LoadROM() {
     for (i = 0; i < 0x240; i++) {
       if (feof(f))
         break;
-      fread(&scratch, 1, 1, f);
+      (void)!fread(&scratch, 1, 1, f);
     }
 
     if (feof(f))
       FAILURE(Runtime, "File is too short to be a SRM ROM image");
     buffer = PtrToMem(0x900000);
     while (!feof(f))
-      fread(buffer++, 1, 1, f);
+      (void)!fread(buffer++, 1, 1, f);
     fclose(f);
 
     printf("%%SYS-I-DECOMP: Decompressing ROM image.\n0%%");
@@ -1924,14 +1924,14 @@ int CSystem::LoadROM() {
   } else {
     printf("%%SYS-I-READROM: Reading decompressed ROM image from %s.\n",
            myCfg->get_text_value("rom.decompressed", "decompressed.rom"));
-    fread(&temp, 1, sizeof(u64), f);
+    (void)!fread(&temp, 1, sizeof(u64), f);
     for (int i = 0; i < iNumCPUs; i++)
       acCPUs[i]->set_pc(endian_64(temp));
-    fread(&temp, 1, sizeof(u64), f);
+    (void)!fread(&temp, 1, sizeof(u64), f);
     for (int i = 0; i < iNumCPUs; i++)
       acCPUs[i]->set_PAL_BASE(endian_64(temp));
     buffer = PtrToMem(0);
-    fread(buffer, 1, 0x200000, f);
+    (void)!fread(buffer, 1, 0x200000, f);
     fclose(f);
   }
 
@@ -2474,14 +2474,14 @@ void CSystem::RestoreState(const char *fn) {
     return;
   }
 
-  fread(&temp_32, sizeof(u32), 1, f);
+  (void)!fread(&temp_32, sizeof(u32), 1, f);
   if (temp_32 != 0xa1fae540) // MAGIC NUMBER (ALFAES40 ==> A1FAE540 )
   {
     printf("%%SYS-F-FORMAT: %s does not appear to be a state file.\n", fn);
     return;
   }
 
-  fread(&temp_32, sizeof(u32), 1, f);
+  (void)!fread(&temp_32, sizeof(u32), 1, f);
 
   if (temp_32 != 0x00020001) // File Format Version 2.1
   {
@@ -2491,16 +2491,16 @@ void CSystem::RestoreState(const char *fn) {
 
   // memory
   for (m = 0; m < memints; m++) {
-    fread(&(mem[m]), 1, sizeof(int), f);
+    (void)!fread(&(mem[m]), 1, sizeof(int), f);
     if (!mem[m]) {
-      fread(&j, 1, sizeof(int), f);
+      (void)!fread(&j, 1, sizeof(int), f);
       while (j--) {
         mem[++m] = 0;
       }
     }
   }
 
-  fread(&state, sizeof(state), 1, f);
+  (void)!fread(&state, sizeof(state), 1, f);
 
   // components
   //

--- a/src/es40_debug.h
+++ b/src/es40_debug.h
@@ -63,12 +63,13 @@
 #define INCLUDED_DEBUG_H
 
 #define DEBUG_BUFSIZE 1024
+#define FAILMSG_BUFSIZE 8000
 #define DEBUG_INDENTATION 4
 
 #ifdef HAVE___FUNCTION__
 #define FAILURE(cls, error_msg)                                                \
   {                                                                            \
-    char where_msg[800];                                                       \
+    char where_msg[FAILMSG_BUFSIZE];;                                                       \
     sprintf(where_msg, "%s, line %i, function '%s'", __FILE__, __LINE__,       \
             __FUNCTION__);                                                     \
     throw C##cls##Exception(error_msg, where_msg);                             \
@@ -77,7 +78,7 @@
 #else
 #define FAILURE(cls, error_msg)                                                \
   {                                                                            \
-    char where_msg[800];                                                       \
+    char where_msg[FAILMSG_BUFSIZE];                                           \
     sprintf(where_msg, "%s, line %i", __FILE__, __LINE__);                     \
     throw C##cls##Exception(error_msg, where_msg);                             \
   }
@@ -85,42 +86,42 @@
 
 #define FAILURE_1(cls, error_msg, a)                                           \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a);                                           \
     FAILURE(cls, what_msg);                                                    \
   }
 
 #define FAILURE_2(cls, error_msg, a, b)                                        \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a, b);                                        \
     FAILURE(cls, what_msg);                                                    \
   }
 
 #define FAILURE_3(cls, error_msg, a, b, c)                                     \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a, b, c);                                     \
     FAILURE(cls, what_msg);                                                    \
   }
 
 #define FAILURE_4(cls, error_msg, a, b, c, d)                                  \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a, b, c, d);                                  \
     FAILURE(cls, what_msg);                                                    \
   }
 
 #define FAILURE_5(cls, error_msg, a, b, c, d, e)                               \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a, b, c, d, e);                               \
     FAILURE(cls, what_msg);                                                    \
   }
 
 #define FAILURE_6(cls, error_msg, a, b, c, d, e, f)                            \
   {                                                                            \
-    char what_msg[800];                                                        \
+    char what_msg[FAILMSG_BUFSIZE];                                            \
     sprintf(what_msg, error_msg, a, b, c, d, e, f);                            \
     FAILURE(cls, what_msg);                                                    \
   }

--- a/src/gui/gui_x11.cpp
+++ b/src/gui/gui_x11.cpp
@@ -296,7 +296,7 @@ void bx_x11_gui_c::specific_init(unsigned tilewidth, unsigned tileheight) {
   y_tilesize = tileheight;
 
   /* connect to X server */
-  if ((bx_x_display = XOpenDisplay(display_name)) == NULL) {
+  if ((bx_x_display = XOpenDisplay(display_name)) == NULL && progname != nullptr) {
     BX_PANIC(("%s: cannot connect to X server %s", progname,
               XDisplayName(display_name)));
   }
@@ -429,11 +429,11 @@ void bx_x11_gui_c::specific_init(unsigned tilewidth, unsigned tileheight) {
     /* These calls store window_name and icon_name into
      * XTextProperty structures and set their other
      * fields properly. */
-    if (XStringListToTextProperty((char **)&window_name, 1, &windowName) == 0) {
+    if (XStringListToTextProperty((char **)&window_name, 1, &windowName) == 0 && progname != nullptr) {
       BX_PANIC(("%s: structure allocation for windowName failed.", progname));
     }
 
-    if (XStringListToTextProperty((char **)&icon_name, 1, &iconName) == 0) {
+    if (XStringListToTextProperty((char **)&icon_name, 1, &iconName) == 0 && progname != nullptr) {
       BX_PANIC(("%s: structure allocation for iconName failed.", progname));
     }
 


### PR DESCRIPTION
When compiling with -Werror -Wall a few warnings pop up on unused variables and a few log macros that could expand to a nullptr.

Where the return values were checked already I did so too, and where there was nothing done with them I made that explicitly by casting. The latter is not the nicest or best, but the few topics I found on it suggested that was an acceptable option.