### PR TITLE
Fix segfault when thrController[0] is not yet initialized

### DIFF
--- a/src/AliM1543C_ide.cpp
+++ b/src/AliM1543C_ide.cpp
@@ -233,7 +233,7 @@
 #include "System.h"
 
 #include <cmath>
-
+#include <iostream>
 #include "gui/keymap.h"
 #include "gui/scancodes.h"
 
@@ -2465,7 +2465,11 @@ int CAliM1543C_ide::do_dma_transfer(int index, u8 *buffer, u32 buffersize,
  * Thread entry point.
  **/
 void CAliM1543C_ide::run() {
-  int index =
+  while (thrController[0] == nullptr) {
+    std::cerr << "CAliM1543C_ide waiting 1 seconds because thrController[0] == nullptr." << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+    int index =
       (thrController[0]->get_id() == std::this_thread::get_id()) ? 0 : 1;
   try {
     for (;;) {


### PR DESCRIPTION
Came across this when debugging issue #6 .

Compiling in debug mode (-Og) gives me a segfault:
```
std::thread::get_id thread:173
CAliM1543C_ide::run AliM1543C_ide.cpp:2470
CAliM1543C_ide::start_threads()::$_0::operator()() const AliM1543C_ide.cpp:445
std::__invoke_impl<void, CAliM1543C_ide::start_threads()::$_0>(std::__invoke_other, CAliM1543C_ide::start_threads()::$_0&&) invoke.h:60
std::__invoke<CAliM1543C_ide::start_threads()::$_0>(CAliM1543C_ide::start_threads()::$_0&&) invoke.h:95
std::thread::_Invoker<std::tuple<CAliM1543C_ide::start_threads()::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) thread:244
std::thread::_Invoker<std::tuple<CAliM1543C_ide::start_threads()::$_0> >::operator()() thread:251
std::thread::_State_impl<std::thread::_Invoker<std::tuple<CAliM1543C_ide::start_threads()::$_0> > >::_M_run() thread:195
<unknown> 0x00007f65e688bd84
start_thread 0x00007f65e6bc3609
clone 0x00007f65e6579103
```