### PR TITLE
OS X: C++ 11 make_unique

### DIFF
--- a/src/StdAfx.hpp
+++ b/src/StdAfx.hpp
@@ -308,4 +308,9 @@ inline char printable(char c) {
 #include "es40_debug.hpp"
 
 #include "es40_endian.hpp"
+
+#if __cplusplus < 201402L
+#include "make_unique.hpp"
+#endif
+
 #endif // !defined(INCLUDED_STDAFX_H)

--- a/src/make_unique.hpp
+++ b/src/make_unique.hpp
@@ -1,0 +1,15 @@
+#ifndef AXPBOX_MAKE_UNIQUE_H
+#define AXPBOX_MAKE_UNIQUE_H
+#include <memory>
+/* Allow C++11 code to use std::make_unique
+ * example ifdef:  #if __cplusplus < 201402L
+ */
+namespace std
+{
+template<typename T, typename ...Args>
+std::unique_ptr<T> make_unique( Args&& ...args )
+{
+  return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+}
+}
+#endif // AXPBOX_MAKE_UNIQUE_H


### PR DESCRIPTION
As I saw in the github actions pull request (#26 ),  compilation with clang on OS X fails due to not having a make_unique (which is a C++ 14 feature). This is a workaround which should do the same.