### PR TITLE
cmake: require C++11, fixes build on macOS Catalina and Big Sur

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(AXPBox VERSION 0.1)
 
 # Source files


### PR DESCRIPTION
Tell cmake to use the correct "-std=" flag with clang. Fixes build with the clang included in Xcode for macOS Catalina and Big Sur on Intel and M1.