### PR TITLE
add autogenerated files from cmake to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CMakeFiles/
 Makefile
 cmake_install.cmake
 src/config.hpp
+axpbox

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build**/
 .idea/
 .vs/
 CMakeSettings.json
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+src/config.hpp


### PR DESCRIPTION
These files get autogenerated when running cmake locally on a Linux system. Add to gitignore to prevent them from getting checked in by mistake.