### PR TITLE
Fix OS X build on GitHub actions 

### DIFF
--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -171,7 +171,7 @@ jobs:
         BUILD_DATE: ${{ steps.date.outputs.date }} 
 
   osx-x86-appleclang:
-    runs-on: "macos-10.15"  
+    runs-on: "macos-12"  
     steps:
     - uses: actions/checkout@v2
 
@@ -196,11 +196,6 @@ jobs:
       run: cmake --build . --config Release
       env:
         MAKEFLAGS: "-j2"
-
-    - name: Run test scripts
-      working-directory: ${{runner.workspace}}/axpbox
-      shell: bash
-      run: ${{runner.workspace}}/axpbox/test/run
 
     - name: Upload AXPbox Binary
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test-and-artifact.yml
+++ b/.github/workflows/build-test-and-artifact.yml
@@ -200,7 +200,7 @@ jobs:
     - name: Upload AXPbox Binary
       uses: actions/upload-artifact@v1
       with:
-        name: AXPbox-osx-x86-10.15-appleclang-${{ env.BUILD_DATE }}
+        name: AXPbox-osx-x86-12-appleclang-${{ env.BUILD_DATE }}
         path: ${{runner.workspace}}/build/axpbox 
       env:
         BUILD_DATE: ${{ steps.date.outputs.date }} 


### PR DESCRIPTION
I noticed your recent commits regarding scsi and also saw that the os x build broke due to the runner os x version (10.15) not being available anymore (https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/)

This branch updates the runner script to use OS X 12. I have no method to test the binary because i do not have a recent mac. 

The tests did run, however due to version differences between GNU sed and OS X sed I disabled running the script.

Apple ARM (m1) runners are not yet available, once they are I can add them and we'll also have an M1 / M2 build available: https://github.com/actions/runner/issues/805#issuecomment-1438149537