### PR TITLE
Draft: Port s3 graphics driver code from @gdwnldsksc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-project(AXPBox VERSION 0.1)
+project(AXPBox VERSION 1.1.2)
 
 # Source files
 file(GLOB srcs src/*.cpp src/base/*.cpp src/gui/*.cpp)

--- a/src/AlphaCPU.hpp
+++ b/src/AlphaCPU.hpp
@@ -494,8 +494,12 @@ inline int CAlphaCPU::get_icache(u64 address, u32 *data) {
         return result;
     }
 
-    memcpy(state.icache[state.next_icache].data, cSystem->PtrToMem(p_a),
+    char* addr = cSystem->PtrToMem(p_a);
+    if(addr)
+      memcpy(state.icache[state.next_icache].data, addr,
            ICACHE_LINE_SIZE * 4);
+    else
+      printf("PtrToMem(p_a) == nullptr! Address: %lu.\n", p_a);
 
     state.icache[state.next_icache].valid = true;
     state.icache[state.next_icache].asn = state.asn;

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -84,8 +84,8 @@
 #define r30 state.r[30]
 #define r31 state.r[31]
 
-#define hw_stq(a, b) cSystem->WriteMem(a & ~U64(0x7), 64, b, this)
-#define hw_stl(a, b) cSystem->WriteMem(a & ~U64(0x3), 32, b, this)
+#define hw_stq(a, b) cSystem->WriteMem((a) & ~U64(0x7), 64, b, this)
+#define hw_stl(a, b) cSystem->WriteMem((a) & ~U64(0x3), 32, b, this)
 #define stq(a, b)                                                              \
   if (virt2phys(a, &phys_address, ACCESS_WRITE, NULL, 0))                      \
     return -1;                                                                 \
@@ -106,8 +106,8 @@
   if (virt2phys(a, &phys_address, ACCESS_READ, NULL, 0))                       \
     return -1;                                                                 \
   b = (char)(cSystem->ReadMem(phys_address, 8, this));
-#define hw_ldq(a, b) b = cSystem->ReadMem(a & ~U64(0x7), 64, this)
-#define hw_ldl(a, b) b = sext_u64_32(cSystem->ReadMem(a & ~U64(0x3), 32, this));
+#define hw_ldq(a, b) b = cSystem->ReadMem((a) & ~U64(0x7), 64, this)
+#define hw_ldl(a, b) b = sext_u64_32(cSystem->ReadMem((a) & ~U64(0x3), 32, this));
 #define hw_ldbu(a, b) b = cSystem->ReadMem(a, 8, this)
 
 /**

--- a/src/S3Trio64.cpp
+++ b/src/S3Trio64.cpp
@@ -327,6 +327,7 @@ void CS3Trio64::init() {
   state.sequencer.sr9 = 0; // Extended Sequencer Register 9 (SR9)
   state.sequencer.srA = 0; // External Bus Request Control (SRA)
   state.sequencer.srB = 0; // Miscellaneous Extended Sequencer Register (SRB)
+  state.sequencer.srD = 0; // Extended Sequencer Register (EX_SR_D) (SRD) 00H poweron
   state.sequencer.sr10 = 0; // CLK Value Low Register (UNLK_EXSR) (SR10)
   state.sequencer.sr11 = 0; // MCLK Value High Register (SR11)
   state.sequencer.sr12 = 0; // DCLK Value Low Register (SR12)
@@ -2774,6 +2775,12 @@ u8 CS3Trio64::read_b_3c5() {
   case 0xA:  // External Bus Request Control Register (SRA)
     return state.sequencer.srA;
 
+  case 0x0b:
+    return state.sequencer.srB;
+
+  case 0x0D:
+    return state.sequencer.srD;
+
   case 0x10:        /* sequencer: SR10 */
     return state.sequencer.sr10;
 
@@ -2782,6 +2789,9 @@ u8 CS3Trio64::read_b_3c5() {
 
   case 0x15:
     return state.sequencer.sr15;
+
+  case 0x18:
+    return state.sequencer.sr18;
 
   default:
     printf("FAIL VGA: 3c5 READ INDEX=0x%02x %d\n", state.sequencer.index, state.sequencer.index);
@@ -2931,9 +2941,9 @@ u8 CS3Trio64::read_b_3d4() { return state.CRTC.address; }
  * For a description of CRTC Registers, see CCirrus::write_b_3d4.
  **/
 u8 CS3Trio64::read_b_3d5() {
-  if((state.CRTC.address > 0x18) && (state.CRTC.address != 0x2e) && (state.CRTC.address != 0x2f) && (state.CRTC.address != 0x36) && \
-    (state.CRTC.address != 0x40) && (state.CRTC.address != 0x42) && (state.CRTC.address != 0x30) && (state.CRTC.address != 0x6b) && \
-    (state.CRTC.address != 0x6c) && (state.CRTC.address != 0x67))
+  if((state.CRTC.address > 0x70) && (state.CRTC.address != 0x2e) && (state.CRTC.address != 0x2f) && (state.CRTC.address != 0x36) &&  
+     (state.CRTC.address != 0x40) && (state.CRTC.address != 0x42) && (state.CRTC.address != 0x30) && (state.CRTC.address != 0x31) &&     
+     (state.CRTC.address != 0x32) && (state.CRTC.address != 0x6b) && (state.CRTC.address != 0x6c) && (state.CRTC.address != 0x67))
   {
     FAILURE_1(NotImplemented, "io read: invalid CRTC register 0x%02x   \n",
               (unsigned)state.CRTC.address);

--- a/src/S3Trio64.hpp
+++ b/src/S3Trio64.hpp
@@ -201,6 +201,7 @@ private:
       u8 sr8; // unlock extended sequencer (SR8)
       u8 srA; // External Bus Request Control (SRA)
       u8 srB; // Miscellaneous Extended Sequencer Register (SRB)
+      u8 srD; // Extended Sequencer Register (EX_SR_D) (SRD)      
       u8    sr10; // CLK Value Low Register (UNLK_EXSR) (SR10)
       u8    sr11; // MCLK Value High Register (SR11)
       u8    sr12; // DCLK Value Low Register (SR12)

--- a/src/S3Trio64.hpp
+++ b/src/S3Trio64.hpp
@@ -91,6 +91,7 @@ private:
   void write_b_3cf(u8 data);
   void write_b_3d4(u8 data);
   void write_b_3d5(u8 data);
+  void write_b_3da(u8 data);
 
   u8 read_b_3c0();
   u8 read_b_3c1();
@@ -98,6 +99,7 @@ private:
   u8 read_b_3c3();
   u8 read_b_3c4();
   u8 read_b_3c5();
+  u8 read_b_3c6();
   u8 read_b_3c9();
   u8 read_b_3ca();
   u8 read_b_3cc();
@@ -143,6 +145,7 @@ private:
             4]; /**< Currently allocates the tile as large as needed. */
     unsigned x_tilesize;
     unsigned y_tilesize;
+    u8 port3da;
 
     struct SS3_attr {
       bool flip_flop;   /* 0 = address, 1 = data-write */
@@ -194,6 +197,19 @@ private:
       bool extended_mem;
       bool odd_even;
       bool chain_four;
+      u8 sr9; // Extended Sequencer Register 9 (SR9)
+      u8 sr8; // unlock extended sequencer (SR8)
+      u8 srA; // External Bus Request Control (SRA)
+      u8 srB; // Miscellaneous Extended Sequencer Register (SRB)
+      u8    sr10; // CLK Value Low Register (UNLK_EXSR) (SR10)
+      u8    sr11; // MCLK Value High Register (SR11)
+      u8    sr12; // DCLK Value Low Register (SR12)
+      u8    sr13; // DCLK Value High Register (SR13)
+      u8    sr14; // CLKSYN Control 1 Register (SR14)
+      u8    sr15; // CLKSYN Control 2 Register (SR15)
+      u8    sr18; // RAMDAC/CLKSYN Control Register (SR18)
+      u8    sr1a; // SR1A ? -
+      u8 sr1b; // SR1B ?
     } sequencer;
 
     struct SS3_pel {
@@ -236,7 +252,7 @@ private:
 
     struct SS3_crtc {
       u8 address;
-      u8 reg[0x20];
+      u8 reg[0x70];
       bool write_protect;
     } CRTC;
   } state;

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -639,23 +639,26 @@ void CSerial::WaitForConnection() {
 
   state.serial_cycles = 0;
 
-  // Send some control characters to the telnet client to handle
-  // character-at-a-time mode.
-  sprintf(buffer, telnet_options, IAC, DO, TELOPT_ECHO);
-  this->write(buffer);
+  if (state.iNumber != 1) // don't send if serial #1, kgdb support
+  {
+      // Send some control characters to the telnet client to handle
+      // character-at-a-time mode.
+      sprintf(buffer, telnet_options, IAC, DO, TELOPT_ECHO);
+      this->write(buffer);
 
-  sprintf(buffer, telnet_options, IAC, DO, TELOPT_NAWS);
-  write(buffer);
+      sprintf(buffer, telnet_options, IAC, DO, TELOPT_NAWS);
+      write(buffer);
 
-  sprintf(buffer, telnet_options, IAC, DO, TELOPT_LFLOW);
-  this->write(buffer);
+      sprintf(buffer, telnet_options, IAC, DO, TELOPT_LFLOW);
+      this->write(buffer);
 
-  sprintf(buffer, telnet_options, IAC, WILL, TELOPT_ECHO);
-  this->write(buffer);
+      sprintf(buffer, telnet_options, IAC, WILL, TELOPT_ECHO);
+      this->write(buffer);
 
-  sprintf(buffer, telnet_options, IAC, WILL, TELOPT_SGA);
-  this->write(buffer);
+      sprintf(buffer, telnet_options, IAC, WILL, TELOPT_SGA);
+      this->write(buffer);
 
-  sprintf(s, "This is serial port #%d on ES40 Emulator\r\n", state.iNumber);
-  this->write(s);
+      sprintf(s, "This is serial port #%d on the AXPBox Emulator\r\n", state.iNumber);
+      this->write(s);
+  }
 }

--- a/src/StdAfx.hpp
+++ b/src/StdAfx.hpp
@@ -213,4 +213,31 @@ inline char printable(char c) {
 #endif
 #endif
 
+
+/* --- PRINTF_BYTE_TO_BINARY macro's --- */
+#define PRINTF_BINARY_PATTERN_INT8 "%c%c%c%c%c%c%c%c"
+#define PRINTF_BYTE_TO_BINARY_INT8(i)    \
+    (((i) & 0x80ll) ? '1' : '0'), \
+    (((i) & 0x40ll) ? '1' : '0'), \
+    (((i) & 0x20ll) ? '1' : '0'), \
+    (((i) & 0x10ll) ? '1' : '0'), \
+    (((i) & 0x08ll) ? '1' : '0'), \
+    (((i) & 0x04ll) ? '1' : '0'), \
+    (((i) & 0x02ll) ? '1' : '0'), \
+    (((i) & 0x01ll) ? '1' : '0')
+
+#define PRINTF_BINARY_PATTERN_INT16 \
+    PRINTF_BINARY_PATTERN_INT8              PRINTF_BINARY_PATTERN_INT8
+#define PRINTF_BYTE_TO_BINARY_INT16(i) \
+    PRINTF_BYTE_TO_BINARY_INT8((i) >> 8),   PRINTF_BYTE_TO_BINARY_INT8(i)
+#define PRINTF_BINARY_PATTERN_INT32 \
+    PRINTF_BINARY_PATTERN_INT16             PRINTF_BINARY_PATTERN_INT16
+#define PRINTF_BYTE_TO_BINARY_INT32(i) \
+    PRINTF_BYTE_TO_BINARY_INT16((i) >> 16), PRINTF_BYTE_TO_BINARY_INT16(i)
+#define PRINTF_BINARY_PATTERN_INT64    \
+    PRINTF_BINARY_PATTERN_INT32             PRINTF_BINARY_PATTERN_INT32
+#define PRINTF_BYTE_TO_BINARY_INT64(i) \
+    PRINTF_BYTE_TO_BINARY_INT32((i) >> 32), PRINTF_BYTE_TO_BINARY_INT32(i)
+/* --- end macros --- */
+
 #endif // !defined(INCLUDED_STDAFX_H)


### PR DESCRIPTION
This is a WIP branch to keep track of the S3 changes in https://github.com/gdwnldsKSC/es40

To test it you need the `86c764x1.bin` video driver:


```
  pci0.1 = s3
  {
    rom = "rom/86c764x1.bin";
  }
```

Startup shows a black screen with blinking cursor. Console log:

```
bus 0, slot 1 -- vga -- S3 Trio64/Trio32
bus 0, slot 3 -- pka -- NCR 53C810
starting drivers
```

[DB014-B_Trio32_Trio64_Graphics_Accelerators_Mar1995.pdf](https://github.com/lenticularis39/axpbox/files/15166400/DB014-B_Trio32_Trio64_Graphics_Accelerators_Mar1995.pdf)
