### PR TITLE
Fix Tru64 5.1B install path on Sym53C810 and PCI DMA

### DIFF
--- a/src/PCIDevice.cpp
+++ b/src/PCIDevice.cpp
@@ -30,6 +30,12 @@
 #include "StdAfx.hpp"
 #include "System.hpp"
 
+static size_t pci_dma_chunk_limit(u64 phys_addr, size_t remaining) {
+  const size_t dma_page = 8192;
+  size_t page_remaining = dma_page - (size_t)(phys_addr & (dma_page - 1));
+  return (remaining < page_remaining) ? remaining : page_remaining;
+}
+
 CPCIDevice::CPCIDevice(CConfigurator *cfg, CSystem *c, int pcibus, int pcidev)
     : CSystemComponent(cfg, c) {
   int i;
@@ -514,16 +520,31 @@ void CPCIDevice::do_pci_read(u32 address, void *dest, size_t element_size,
   // if we're transferring bytes. Otherwise, endian-conversions need to be done.
   if (element_size == 1) {
 #endif
+    size_t remaining = element_size * element_count;
+    u32 cur_address = address;
 
-    // get a pointer to system memory if the address is inside main memory
-    char *memptr = cSystem->PtrToMem(phys_addr);
+    while (remaining != 0) {
+      u64 cur_phys = cSystem->PCI_Phys(myPCIBus, cur_address);
+      size_t chunk = pci_dma_chunk_limit(cur_phys, remaining);
 
-    // if the address is inside system memory, a simple memcpy operation is
-    // all that is needed.
-    if (memptr) {
-      memcpy(dest, memptr, element_size * element_count);
-      return;
+      // get a pointer to system memory if the address is inside main memory
+      char *memptr = cSystem->PtrToMem(cur_phys);
+
+      // Copy only within a single translated DMA page. Scatter-gather DMA does
+      // not guarantee that adjacent PCI bus addresses map to contiguous host
+      // physical memory beyond the current page.
+      if (memptr) {
+        memcpy(dst, memptr, chunk);
+      } else {
+        for (el = 0; el < chunk; el++)
+          dst[el] = (u8)cSystem->ReadMem(cur_phys + el, 8, this);
+      }
+
+      dst += chunk;
+      cur_address += (u32)chunk;
+      remaining -= chunk;
     }
+    return;
 
 #if defined(ES40_BIG_ENDIAN)
   }
@@ -549,7 +570,6 @@ void CPCIDevice::do_pci_read(u32 address, void *dest, size_t element_size,
   case 4: {
     *(u32 *)dst = endian_32((u32)cSystem->ReadMem(phys_addr, 32, this));
     dst += 4;
-    ;
     phys_addr += 4;
   } break;
 
@@ -601,16 +621,28 @@ void CPCIDevice::do_pci_write(u32 address, void *source, size_t element_size,
   // if we're transferring bytes. Otherwise, endian-conversions need to be done.
   if (element_size == 1) {
 #endif
+    size_t remaining = element_size * element_count;
+    u32 cur_address = address;
 
-    // get a pointer to system memory if the address is inside main memory
-    char *memptr = cSystem->PtrToMem(phys_addr);
+    while (remaining != 0) {
+      u64 cur_phys = cSystem->PCI_Phys(myPCIBus, cur_address);
+      size_t chunk = pci_dma_chunk_limit(cur_phys, remaining);
 
-    // if the address is inside system memory, a simple memcpy operation is
-    // all that is needed.
-    if (memptr) {
-      memcpy(memptr, source, element_size * element_count);
-      return;
+      // get a pointer to system memory if the address is inside main memory
+      char *memptr = cSystem->PtrToMem(cur_phys);
+
+      if (memptr) {
+        memcpy(memptr, src, chunk);
+      } else {
+        for (el = 0; el < chunk; el++)
+          cSystem->WriteMem(cur_phys + el, 8, (u8)src[el], this);
+      }
+
+      src += chunk;
+      cur_address += (u32)chunk;
+      remaining -= chunk;
     }
+    return;
 
 #if defined(ES40_BIG_ENDIAN)
   }
@@ -636,7 +668,6 @@ void CPCIDevice::do_pci_write(u32 address, void *source, size_t element_size,
   case 4: {
     cSystem->WriteMem(phys_addr, 32, endian_32(*(u32 *)src), this);
     src += 4;
-    ;
     phys_addr += 4;
   } break;
 

--- a/src/Sym53C810.cpp
+++ b/src/Sym53C810.cpp
@@ -1585,7 +1585,13 @@ void CSym53C810::execute_bm_op() {
          table_indirect, opcode, scsi_phase);
 #endif
   // Compare phase
-  if (check_phase(scsi_phase) > 0) {
+  int phase_ok = check_phase(scsi_phase);
+  if (phase_ok == 0) {
+    RAISE(SIST0, MA);
+    return;
+  }
+
+  if (phase_ok > 0) {
 #if defined(DEBUG_SYM_SCRIPTS)
     printf("SYM: Ready for transfer.\n");
 #endif
@@ -1615,7 +1621,7 @@ void CSym53C810::execute_bm_op() {
     printf("SYM: %08x: MOVE Start/count %x, %x\n", R32(DSP) - 8, start, count);
 #endif
     R32(DNAD) = start;
-    SET_DBC(count); // page 5-32
+    SET_DBC(count);
     if (count == 0) {
 
       // printf("SYM: Count equals zero!\n");
@@ -1623,35 +1629,58 @@ void CSym53C810::execute_bm_op() {
       return;
     }
 
-    if ((size_t)count > scsi_expected_xfer(0)) {
+    for (;;) {
+      size_t expected = scsi_expected_xfer(0);
+      u32 remaining = GET_DBC();
+      u32 xfer = remaining;
+
+      if ((size_t)xfer > expected) {
 #if defined(DEBUG_SYM_SCRIPTS)
-      printf("SYM: xfer %d bytes, max %d expected, in phase %d.\n", count,
-             scsi_expected_xfer(0), scsi_phase);
+        printf("SYM: xfer %d bytes, max %zu expected, in phase %d.\n", xfer,
+               expected, scsi_phase);
 #endif
-      count = (u32)scsi_expected_xfer(0);
+        xfer = (u32)expected;
+      }
+
+      if (xfer == 0) {
+        RAISE(SIST0, MA);
+        return;
+      }
+
+      u8 *scsi_data_ptr = (u8 *)scsi_xfer_ptr(0, xfer);
+      u8 *org_sdata_ptr = scsi_data_ptr;
+
+      switch (scsi_phase) {
+      case SCSI_PHASE_COMMAND:
+      case SCSI_PHASE_DATA_OUT:
+      case SCSI_PHASE_MSG_OUT:
+        do_pci_read(R32(DNAD), scsi_data_ptr, 1, xfer);
+        R32(DNAD) += xfer;
+        break;
+
+      case SCSI_PHASE_STATUS:
+      case SCSI_PHASE_DATA_IN:
+      case SCSI_PHASE_MSG_IN:
+        do_pci_write(R32(DNAD), scsi_data_ptr, 1, xfer);
+        R32(DNAD) += xfer;
+        break;
+      }
+
+      SET_DBC(remaining - xfer);
+      R8(SFBR) = *org_sdata_ptr;
+      scsi_xfer_done(0);
+
+      if (GET_DBC() == 0)
+        return;
+
+      phase_ok = check_phase(scsi_phase);
+      if (phase_ok <= 0) {
+        if (phase_ok == 0) {
+          RAISE(SIST0, MA);
+        }
+        return;
+      }
     }
-
-    u8 *scsi_data_ptr = (u8 *)scsi_xfer_ptr(0, count);
-    u8 *org_sdata_ptr = scsi_data_ptr;
-
-    switch (scsi_phase) {
-    case SCSI_PHASE_COMMAND:
-    case SCSI_PHASE_DATA_OUT:
-    case SCSI_PHASE_MSG_OUT:
-      do_pci_read(R32(DNAD), scsi_data_ptr, 1, count);
-      R32(DNAD) += count;
-      break;
-
-    case SCSI_PHASE_STATUS:
-    case SCSI_PHASE_DATA_IN:
-    case SCSI_PHASE_MSG_IN:
-      do_pci_write(R32(DNAD), scsi_data_ptr, 1, count);
-      R32(DNAD) += count;
-      break;
-    }
-
-    R8(SFBR) = *org_sdata_ptr;
-    scsi_xfer_done(0);
     return;
   }
 }


### PR DESCRIPTION
This fixes the historical Tru64 5.1B installer failure during AdvFS root creation.

On current `main`, Tru64 5.1B would boot and enter the installer, but fail while creating the root AdvFS domain and fileset. After these two changes, the installer proceeds past root/usr/var/swap creation and into software subset loading.

## Sym53C810: preserve residual state across short SCSI moves

This change tightens the NCR 53C810 SCRIPTS Block Move implementation to better match the documented controller behavior.

Primary reference:
- [NCR 53C810 PCI-SCSI I/O Processor Data Manual](https://bitsavers.trailing-edge.com/components/ncr_symbios/scsi/53C810/53C810_PCI-SCSI_IO_Processor_Data_Manual_May1993.pdf), especially the SCRIPTS Block Move semantics and the role of `DBC`, `DNAD`, and phase mismatch handling.

What was wrong in the previous implementation:
- `execute_bm_op()` clamped a single transfer to `scsi_expected_xfer()` and then returned immediately.
- When the target accepted fewer bytes than the original Block Move requested, the code advanced `DNAD` for the bytes transferred but did not preserve the residual move correctly in `DBC`.
- Immediate phase mismatch was not turned into the expected `SIST0.MA` handling path.
- In effect, a short transfer could be treated as if the whole SCRIPTS move had completed, instead of leaving a resumable residual move for the script engine.

What this change does:
- raises `SIST0.MA` on an immediate phase mismatch,
- transfers only the amount currently legal for the active phase,
- decrements `DBC` by the bytes actually transferred,
- increments `DNAD` by the bytes actually transferred,
- continues within the same Block Move until either the residual count reaches zero or the phase changes.

That matches the documented 53C810 model more closely: `DBC`/`DNAD` track the residual transfer state, and a phase mismatch terminates the current transfer with mismatch status instead of silently consuming the whole move.

## PCIDevice: split byte DMA across translated pages

This fixes a separate DMA mapping bug that turned out to be the change that moved the Tru64 installer past the AdvFS failure.

What was wrong:
- the byte-transfer fast path in `do_pci_read()` / `do_pci_write()` assumed that one `PCI_Phys()` translation plus one `PtrToMem()` pointer was valid for the entire transfer range,
- that assumption is unsafe when adjacent PCI bus addresses do not map to one contiguous host memory span.

What this change does:
- splits byte DMA transfers into chunks bounded by the current translated page,
- re-runs `PCI_Phys()` for each chunk,
- uses `PtrToMem()` only for that chunk, and otherwise falls back to bytewise memory access.

This avoids copying across translation boundaries as if the guest DMA buffer were one contiguous host span.

## Validation

Validated manually with a fresh Tru64 5.1B install image and disk image:
- before these changes: installer failed during AdvFS root-domain/fileset creation,
- after these changes: installer completed root/usr/var/swap creation and proceeded into loading software subsets.