### PR TITLE
Add faketime config option for guest clock override

### DIFF
--- a/es40.cfg
+++ b/es40.cfg
@@ -169,6 +169,14 @@ sys0 = tsunami {
   //
   memory.bits = 30;
 
+  // VARIABLE: time
+  //
+  // Override the guest clock with a fixed date/time.
+  // Format: "YYYY-MM-DD" or "YYYY-MM-DD HH:MM:SS"
+  //
+  //time = "2017-05-01";              // fake date (YYYY-MM-DD)
+  //time = "2017-05-01 12:00:00";     // fake date+time (YYYY-MM-DD HH:MM:SS)
+
   cpu0 = ev68cb {
     // VARIABLE: icache
     //

--- a/src/AliM1543C.cpp
+++ b/src/AliM1543C.cpp
@@ -300,6 +300,41 @@ struct tm CAliM1543C::get_time() {
   bool offset_present = false;
   long offset;
 
+  // Check for absolute time override: "YYYY-MM-DD" or "YYYY-MM-DD HH:MM:SS"
+  // Read from system-level config (sys0 block)
+  char *faketime = myCfg->get_myParent()->get_text_value("time");
+  if (faketime) {
+    struct tm ft;
+    memset(&ft, 0, sizeof(ft));
+    ft.tm_isdst = -1; // let mktime figure it out
+    int n = sscanf(faketime, "%d-%d-%d %d:%d:%d", &ft.tm_year, &ft.tm_mon,
+                   &ft.tm_mday, &ft.tm_hour, &ft.tm_min, &ft.tm_sec);
+    if (n >= 3) {
+      ft.tm_year -= 1900;
+      ft.tm_mon -= 1;
+      time_raw = mktime(&ft);
+      if (time_raw == (time_t)-1) {
+        FAILURE_1(Configuration, "Invalid time value: %s", faketime);
+      }
+      // Apply timezone conversion and return
+      if (timezone.rfind("utc") == 0) {
+        gmtime_s(&time_out, &time_raw);
+      } else {
+#ifdef _WIN32
+        localtime_s(&time_out, &time_raw);
+#else
+        localtime_s(&time_raw, &time_out);
+#endif
+      }
+      return time_out;
+    } else {
+      FAILURE_1(Configuration,
+                "Invalid time format: %s (use YYYY-MM-DD or "
+                "YYYY-MM-DD HH:MM:SS)",
+                faketime);
+    }
+  }
+
   // Get raw time
   time(&time_raw);
 

--- a/src/DPR.cpp
+++ b/src/DPR.cpp
@@ -76,6 +76,21 @@ void CDPR::init() {
 
     // powerup time BCD:
     time_t now = time(NULL);
+
+    // Check for absolute time override at system level
+    char *faketime = myCfg->get_text_value("time");
+    if (faketime) {
+      struct tm ft;
+      memset(&ft, 0, sizeof(ft));
+      ft.tm_isdst = -1;
+      if (sscanf(faketime, "%d-%d-%d %d:%d:%d", &ft.tm_year, &ft.tm_mon,
+                 &ft.tm_mday, &ft.tm_hour, &ft.tm_min, &ft.tm_sec) >= 3) {
+        ft.tm_year -= 1900;
+        ft.tm_mon -= 1;
+        now = mktime(&ft);
+      }
+    }
+
     struct tm *t = localtime(&now);
     state.ram[i * 0x20 + 0x10] = ToBCD(t->tm_hour);
     state.ram[i * 0x20 + 0x11] = ToBCD(t->tm_min);


### PR DESCRIPTION
The same could be achieved using libfaketime but if capablities are added, or sudo is used, LD_PRELOAD is not honoured by default which makes using the lib more complicated. This options simplifies the setup to use custom time.

This is helpful for having a real retro vibe if you want to run your alpha box in the 1990s. There are probably also other useful use cases for this feature.